### PR TITLE
feat: Add some basic infix fns comparing `Imandra_ptime.t` s

### DIFF
--- a/src-extra/imandra_ptime_extra.iml
+++ b/src-extra/imandra_ptime_extra.iml
@@ -23,6 +23,14 @@ let ns_count_in_day = 86_400_000_000_000
 let ps_count_in_day = 86_400_000_000_000_000
 let s_count_in_day = 86_400
 
+module Infix = struct
+  let ( < ) t1 t2 = Imandra_ptime.compare t1 t2 < 0
+  let ( > ) t1 t2 = Imandra_ptime.compare t1 t2 > 0
+  let ( = ) = Imandra_ptime.equal
+  let ( <= ) t1 t2 = Imandra_ptime.compare t1 t2 <= 0
+  let ( >= ) t1 t2 = Imandra_ptime.compare t1 t2 >= 0
+end
+
 (** Possible weeks in the month *)
 type week = Week_1 | Week_2 | Week_3 | Week_4 | Week_5
 

--- a/src-extra/imandra_ptime_extra.mli
+++ b/src-extra/imandra_ptime_extra.mli
@@ -20,6 +20,14 @@ val ns_count_in_day : Z.t
 val ps_count_in_day : Z.t
 val s_count_in_day : Z.t
 
+module Infix : sig
+  val ( < ) : t -> t -> bool
+  val ( > ) : t -> t -> bool
+  val ( = ) : t -> t -> bool
+  val ( <= ) : t -> t -> bool
+  val ( >= ) : t -> t -> bool
+end
+
 type week = Week_1 | Week_2 | Week_3 | Week_4 | Week_5
 
 val compare_week : week -> week -> Z.t


### PR DESCRIPTION
Just adding some really basic infix stuff. Really it is just proving useful for porting sigmax to using `Imandra_ptime`. 